### PR TITLE
Readme.md: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Now, let's Download ConquerOS Source
 - First, make directory for ConquerOS Source, and then enter to the directory.
 ```
 $ mkdir -p ~/conquer
-$ cd /conquer
+$ cd ~/conquer
 ```
 
 - Second, initialize ConquerOS Source manifest in the directory


### PR DESCRIPTION
I think this is a typo because there is no /conquer directory after running mkdir -p ~/conquer?